### PR TITLE
Update rust to 1.70

### DIFF
--- a/focal/Dockerfile
+++ b/focal/Dockerfile
@@ -97,8 +97,8 @@ RUN asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git \
 
  # Rust
  RUN asdf plugin-add rust \
-   && asdf install rust 1.65.0 \
-   && asdf global rust 1.65.0 \
+   && asdf install rust 1.70.0 \
+   && asdf global rust 1.70.0 \
    && rm -rf /tmp/*
 
 # Multimedia libraries


### PR DESCRIPTION
This update is especially useful because of the new crates.io sparse protocol fully stabilized in 1.70, which can significantly reduce crate download times. I estimate at least a 50% improvement in rust compilation times on the CI.