### PR TITLE
Bump version of actions/checkout

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
  build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2


### PR DESCRIPTION
`@2` causes an error because of dependency to the deprecated version of `node`